### PR TITLE
set-cookie-parser is a devDependency and chai is not

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "node": ">=4"
   },
   "dependencies": {
-    "chai": "^3.5.0"
+    "set-cookie-parser": "^2.0.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "express": "^4.15.2",
     "mocha": "~3.2.0",
     "node-fetch": "^1.6.3",
-    "set-cookie-parser": "^2.0.0",
     "sinon": "~1.17.6"
   }
 }


### PR DESCRIPTION
Minor fixes:
 - set-cookie-parser is actually a [dependency](https://github.com/kfiron/node-fetch-response-matchers/blob/master/lib/cookie-methods.js#L2);
 - chai is not a dependency - you don't want to force it onto your clients - if they are using these matchers they for sure have chai already:) Now if this library is sensitive about chai versions, you could make it a `peerDependency` and have semver range to signal which chai versions are supported.