### PR TITLE
added bad-request status matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can all use chai "not"
 | ---------------------|----------| ---------------------------------|
 | successful()         | ()       | Assert that the status is 200 OK |
 | created()            | ()       | Assert that the status is 201    |
+| badRequest()         | ()       | Assert that the status is 400    |
 | unauthorized()       | ()       | Assert that the status is 401    |
 | rejected()           | ()       | Assert that the status is 403    |
 | notFound()           | ()       | Assert that the status is 404    |

--- a/lib/status-methods.js
+++ b/lib/status-methods.js
@@ -3,6 +3,7 @@
 module.exports = methodBuilder => {
   statusMethod('successful', 200);
   statusMethod('created', 201);
+  statusMethod('badRequest', 400);
   statusMethod('unauthorized', 401);
   statusMethod('rejected', 403);
   statusMethod('notFound', 404);
@@ -30,5 +31,4 @@ module.exports = methodBuilder => {
       }
     });
   }
-
 };

--- a/test/status-tests-matchers.spec.js
+++ b/test/status-tests-matchers.spec.js
@@ -3,7 +3,6 @@ const expect = require('chai').expect,
   chai = require('chai'),
   err = require('./drivers/test-helpers').err,
   beforeAndAfter = require('./drivers/test-helpers').beforeAndAfter,
-  collaborator = require('./drivers/collaborator'),
   nodeFetch = require('./drivers/fetch-driver'),
   nodeFetchMatchers = require('..');
 
@@ -33,6 +32,9 @@ describe('status fetch matchers', function () {
           'expected http status 401 to equal 201',
           done)
       });
+      it('badRequest', () => {
+        return expect(nodeFetch.fetchNotSuccess()).to.be.a.badRequest();
+      });
       it('unauthorized', () => {
         return expect(nodeFetch.fetchUnauthorized()).to.be.unauthorized();
       });
@@ -58,8 +60,5 @@ describe('status fetch matchers', function () {
           done);
       });
     });
-
   });
-
-
 });


### PR DESCRIPTION
in order to use: `expect(fetch('/a/b')).to.be.a.badRequest()`
instead of `expect(fetch('/a/b')).to.haveStatus(400)`